### PR TITLE
Fix LaTeX percent macro syntax highlighting

### DIFF
--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -9,6 +9,12 @@ import 'prismjs-bibtex'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.js'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
+// Override the default LaTeX comment rule so that the percent sign macro (\%)
+// isn't treated as the start of a comment.
+Prism.languages.latex.comment = {
+  pattern: /(?<!\\)%.*$/m,
+}
+
 // Ensure Prism is available globally for plugins
 if (typeof window !== 'undefined') {
   (window as any).Prism = Prism;


### PR DESCRIPTION
## Summary
- override Prism's LaTeX comment rule so escaped percent signs are not treated as comments

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ff5f5de4832cac0daad1ed7fe990)