### PR TITLE
Select URL input text on focus

### DIFF
--- a/src/components/ArxivInput.tsx
+++ b/src/components/ArxivInput.tsx
@@ -36,6 +36,7 @@ export default function ArxivInput({ onSubmit, loading, value, onChange }: Arxiv
           type="text"
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
+          onFocus={(e) => e.target.select()}
           placeholder="Enter arXiv URL or ID (e.g., https://arxiv.org/abs/1706.03762 or 1706.03762)"
           disabled={loading}
           className="arxiv-url-input"


### PR DESCRIPTION
## Summary
- select the URL input contents when the field receives focus

## Testing
- npm run lint (fails: existing lint error in src/components/FileViewer.tsx about no-explicit-any)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921031ceb68832c84ef0bb95f7e1032)